### PR TITLE
Feature: Support Twitter verifications

### DIFF
--- a/app.js
+++ b/app.js
@@ -79,11 +79,4 @@ app.post('/challenge/:platform', async (req, res) => {
   return res.status(400);
 });
 
-app.post('/callback', (req, res) => {
-  console.log("Callback received!");
-  console.log(req.params);
-
-  return res.status(400);
-});
-
 export default app;

--- a/app.js
+++ b/app.js
@@ -63,17 +63,25 @@ app.post('/verify/:platform', async (req, res) => {
   });
 });
 
-app.post('/challenge/:platform', (req, res) => {
+app.post('/challenge/:platform', async (req, res) => {
   const { platform } = req.params;
   const { accountId, handle } = req.body;
 
   if (platform in verifiers) {
     const { [platform]: verifier } = verifiers;
+    const challenge = await verifier.getChallenge(accountId, handle);
 
     return res.status(200).json({
-      challenge: verifier.getChallenge(accountId, handle)
+      challenge
     });
   }
+
+  return res.status(400);
+});
+
+app.post('/callback', (req, res) => {
+  console.log("Callback received!");
+  console.log(req.params);
 
   return res.status(400);
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "nearbadger-verifiers-api",
+  "name": "nearbadger-api",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -15,7 +15,8 @@
         "express": "^4.18.2",
         "js-sha256": "^0.11.0",
         "module-alias": "^2.2.3",
-        "near-api-js": "^3.0.2"
+        "near-api-js": "^3.0.2",
+        "twitter-api-v2": "^1.16.0"
       },
       "devDependencies": {
         "jest": "^29.7.0",
@@ -4899,6 +4900,11 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
       "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+    },
+    "node_modules/twitter-api-v2": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/twitter-api-v2/-/twitter-api-v2-1.16.0.tgz",
+      "integrity": "sha512-e7wzWqx5oQZ9IUc2xt8JiJ84ioVGlmjmca1h0NwCKx2AFfKXDePmQa42gcBDe0qau9YaHsIpzO9z5SX1fmb+IQ=="
     },
     "node_modules/type-detect": {
       "version": "4.0.8",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "express": "^4.18.2",
     "js-sha256": "^0.11.0",
     "module-alias": "^2.2.3",
-    "near-api-js": "^3.0.2"
+    "near-api-js": "^3.0.2",
+    "twitter-api-v2": "^1.16.0"
   },
   "scripts": {
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js"

--- a/utils/nearbadger.js
+++ b/utils/nearbadger.js
@@ -1,10 +1,11 @@
 import { Wallet } from './near.js';
+import NearVerifier from '../verifiers/near.js';
 import crypto from 'crypto';
 
 export default class NearBadger {
   static issue({accountId, platform, handle, proof}) {
     const wallet = new Wallet();
-    const nonce = crypto.randomBytes(16).readUIntBE(0, 6);
+    const nonce = this.getSafeNonce();
     const message = `${accountId},${platform},${handle},${proof},${nonce}`;
     const rawSignature = wallet.sign(message)?.signature || [];
 
@@ -12,5 +13,13 @@ export default class NearBadger {
       nonce,
       signature: Array.from(rawSignature)
     };
+  }
+  static getSafeNonce() {
+    return crypto.randomBytes(16).readUIntBE(0, 6);
+  }
+  static verifyIsMe(message, signatureBase64) {
+    const verifier = new NearVerifier();
+
+    return verifier.testPublicKeys([process.env.SIGNER_PUBLIC_KEY || ""], message, signatureBase64);
   }
 }

--- a/utils/twitter.js
+++ b/utils/twitter.js
@@ -1,0 +1,25 @@
+import { TwitterApi } from "twitter-api-v2";
+
+const REQUEST_OAUTH_TOKEN_ENDPOINT = 'oauth/request_token';
+
+export class TwitterAPI {
+    client = null;
+
+    constructor() {
+        this.client = new TwitterApi({
+            appKey: process.env.TWITTER_API_KEY,
+            appSecret: process.env.TWITTER_SECRET_KEY,
+        });
+    }
+
+    async generateAuthURL() {
+        // Obtener el token de solicitud y la URL de autenticación
+        const { url, oauth_token, oauth_token_secret } = await this.client.generateAuthLink('https://near.org/mattb.near/widget/NearBadger.Pages.Main');
+
+        // Guarda oauth_token y oauth_token_secret en tu sesión o almacenamiento seguro
+        // Necesitarás estos valores después de que el usuario autorice tu aplicación para obtener el token de acceso
+
+        console.log('URL de autenticación:', url);
+        return url;
+    }
+};

--- a/utils/twitter.js
+++ b/utils/twitter.js
@@ -1,5 +1,7 @@
-import { TwitterApi } from "twitter-api-v2";
+import { TwitterApi } from 'twitter-api-v2';
+import badger from './nearbadger.js';
 
+const TWITTER_AUTH_URL = 'https://twitter.com/i/oauth2/authorize';
 const REQUEST_OAUTH_TOKEN_ENDPOINT = 'oauth/request_token';
 
 export class TwitterAPI {
@@ -11,15 +13,63 @@ export class TwitterAPI {
             appSecret: process.env.TWITTER_SECRET_KEY,
         });
     }
+}
 
-    async generateAuthURL() {
-        // Obtener el token de solicitud y la URL de autenticación
-        const { url, oauth_token, oauth_token_secret } = await this.client.generateAuthLink('https://near.org/mattb.near/widget/NearBadger.Pages.Main');
-
-        // Guarda oauth_token y oauth_token_secret en tu sesión o almacenamiento seguro
-        // Necesitarás estos valores después de que el usuario autorice tu aplicación para obtener el token de acceso
-
-        console.log('URL de autenticación:', url);
-        return url;
+export class TwitterAuth {
+    async generateAuthURL(state, redirectUri) {
+        return this.getBaseURL({
+            clientId: process.env.TWITTER_OAUTH_CLIENT_ID || '',
+            state,
+            redirectUri
+        });
     }
-};
+
+    async generateChallenge(accountId, handle) {
+        const platform = 'twitter';
+        const nonce = badger.getSafeNonce();
+        const rawChallenge = this.getRawChallenge({
+            accountId,
+            handle,
+            platform,
+            nonce
+        });
+        const signature = Buffer.from(
+            badger.sign(rawChallenge)
+        ).toString('base64');
+
+        return Buffer.from(`${rawChallenge},${signature}`).toString("base64");
+    }
+
+    decodeChallenge(encodedChallenge) {
+        const decodedChallenge = Buffer.from(encodedChallenge).toString('utf-8');
+        const [accountId, handle, platform, nonce, encodedSignature] = decodedChallenge.split(',');
+        
+        return {
+            challenge: this.getRawChallenge({
+                accountId, 
+                handle, 
+                platform, 
+                nonce
+            }),
+            signature: encodedSignature
+        };
+    }
+
+    getRawChallenge({ accountId, handle, platform, nonce }) {
+        return `${accountId},${handle},${platform},${nonce}`;
+    }
+
+    getBaseURL({ clientId, state, redirectUri }) {
+        const searchParams = new URLSearchParams({
+            state,
+            code_challenge_method: 'plain',
+            code_challenge: 'nearbadger',
+            client_id: clientId,
+            scope: 'users.read',
+            response_type: 'code',
+            redirect_uri: encodeURIComponent(redirectUri)
+        });
+
+        return `${TWITTER_AUTH_URL}?${searchParams.toString()}`;
+    }
+}

--- a/verifiers/index.js
+++ b/verifiers/index.js
@@ -1,10 +1,12 @@
 import LensVerifier from "./lens.js";
 import FarcasterVerifier from "./farcaster.js";
+import TwitterVerifier from "./twitter.js";
 import NearVerifier from './near.js';
 
 const Verifiers = {
     lens: new LensVerifier(),
     farcaster: new FarcasterVerifier(),
+    twitter: new TwitterVerifier(),
     near: new NearVerifier()
 }
 

--- a/verifiers/near.js
+++ b/verifiers/near.js
@@ -6,6 +6,9 @@ export default class NearVerifier {
     verify(accountId, message, signatureBase64) {
         const rpc = new NearRPC();
         const pubKeys = rpc.getAccountFullAccessPubKeys(accountId);
+        return this.testPublicKeys(pubKeys, message, signatureBase64);
+    }
+    testPublicKeys(pubKeys, message, signatureBase64) {
         const messageToVerify = Uint8Array.from(js_sha256.sha256.array(message));
         const signature = Buffer.from(signatureBase64, 'base64');
 

--- a/verifiers/twitter.js
+++ b/verifiers/twitter.js
@@ -1,7 +1,7 @@
-import { LensAPI } from '../utils/lens.js';
+import { TwitterAPI } from '../utils/twitter.js';
 import AbstractVerifier from './verifier.js';
 
-export default class LensVerifier extends AbstractVerifier {
+export default class TwitterVerifier extends AbstractVerifier {
   async verify(accountId, handle, proof) {
     const api = new LensAPI();
     const fullHandle = this.getFullHandle(handle);
@@ -10,10 +10,10 @@ export default class LensVerifier extends AbstractVerifier {
     
     return expectedSigner?.toLowerCase() === this.getSignerAddress(challenge, proof).toLowerCase();
   }
-  getFullHandle(handle) {
-    let parts = handle.split(".");
-    let namespace = parts.pop();
-
-    return `${namespace}/${parts.shift()}`;
+  async getChallenge() {
+    const api = new TwitterAPI();
+    const challenge = await api.generateAuthURL();
+    
+    return challenge;
   }
 }

--- a/verifiers/twitter.js
+++ b/verifiers/twitter.js
@@ -1,19 +1,48 @@
-import { TwitterAPI } from '../utils/twitter.js';
+import { TwitterApi } from 'twitter-api-v2';
+import badger from '../utils/nearbadger.js';
+import { TwitterAuth, TwitterAPI } from '../utils/twitter.js';
 import AbstractVerifier from './verifier.js';
 
+const DEFAULT_REDIRECT_URI = 'https://near.org/mattb.near/widget/NearBadger.Pages.Main';
+
 export default class TwitterVerifier extends AbstractVerifier {
-  async verify(accountId, handle, proof) {
-    const api = new LensAPI();
-    const fullHandle = this.getFullHandle(handle);
-    const challenge = this.getChallenge(accountId, handle);
-    const expectedSigner = await api.getHandleOwner(fullHandle);
-    
-    return expectedSigner?.toLowerCase() === this.getSignerAddress(challenge, proof).toLowerCase();
+  auth = null;
+
+  constructor() {
+    super();
+
+    this.auth = new TwitterAuth();
   }
-  async getChallenge() {
-    const api = new TwitterAPI();
-    const challenge = await api.generateAuthURL();
+  async verify(accountId, handle, proof, encodedChallenge) {
+    const challenge = this.auth.decodeChallenge(encodedChallenge);
     
+    if (this.verifyChallenge(challenge)) {
+      const initialAccountId = challenge.challenge.accountId; // We can trust this value now
+
+      if (initialAccountId === accountId) {
+        const api = new TwitterApi();
+
+        // @TODO: Initialize the Twitter API with user's token and verify if the Twitter handle
+        // matches the handle the user is trying to claim. If it matches - return true
+      }
+    }
+
+    return false;
+  }
+  getChallenge(accountId, handle) {
+    const state = this.auth.generateChallenge(accountId, handle);
+    const redirectUri = this.getRedirectUri();
+    const challenge = this.auth.generateAuthURL(state, redirectUri);
+
     return challenge;
+  }
+  getRedirectUri() {
+      return DEFAULT_REDIRECT_URI;
+  }
+  verifyChallenge(challenge) {
+    const rawChallenge = challenge.challenge;
+    const encodedSignature = challenge.signature;
+
+    return badger.verifyIsMe(rawChallenge, encodedSignature);
   }
 }


### PR DESCRIPTION
This PR adds support for verifying Twitter handles. Although it should be safe to use, we need to make a change in the challenge generation so that every verification uses the same approach that has been implemented for Twitter challenges.